### PR TITLE
Added tests for floats

### DIFF
--- a/tests/test_float.py
+++ b/tests/test_float.py
@@ -1,0 +1,27 @@
+import pytest
+import rapidjson
+
+
+@pytest.mark.unit
+def test_infinity():
+    inf = float("inf")
+    dumped = rapidjson.dumps(inf)
+    loaded = rapidjson.loads(dumped)
+    assert loaded == inf
+
+
+@pytest.mark.unit
+def test_negative_infinity():
+    inf = float("-infinity")
+    dumped = rapidjson.dumps(inf)
+    loaded = rapidjson.loads(dumped)
+    assert loaded == inf
+
+
+@pytest.mark.unit
+def test_nan():
+    nan = float("nan")
+    dumped = rapidjson.dumps(nan)
+    loaded = rapidjson.loads(dumped)
+
+    assert loaded == nan


### PR DESCRIPTION
@kenrobbins This shows we get unexpected behavior sometimes when working with Infinity/NaN especially the result of dumps:

```
(Pdb) import ujson
(Pdb) import simplejson
(Pdb) ujson.dumps(inf)
*** OverflowError: Invalid Inf value when encoding double
(Pdb) simplejson.dumps(inf)
'Infinity'
```

This is what rapidjson gives:

```python
>>> inf = float('infinity')
>>> import rapidjson
>>> rapidjson.dumps(inf)
'1.797693134862316e308'
```