### PR TITLE
Fix issue #38: null-bytes were not dumped correctly

### DIFF
--- a/python-rapidjson/rapidjson.cpp
+++ b/python-rapidjson/rapidjson.cpp
@@ -561,15 +561,18 @@ rapidjson_dumps_internal(
                 writer->Double(d);
         }
         else if (PyBytes_Check(object)) {
-            char* s = PyBytes_AsString(object);
-            if (s == NULL)
+            Py_ssize_t l;
+            char* s;
+
+            if (PyBytes_AsStringAndSize(object, &s, &l) == -1)
                 goto error;
 
-            writer->String(s);
+            writer->String(s, l);
         }
         else if (PyUnicode_Check(object)) {
-            char* s = PyUnicode_AsUTF8(object);
-            writer->String(s);
+            Py_ssize_t l;
+            char* s = PyUnicode_AsUTF8AndSize(object, &l);
+            writer->String(s, l);
         }
         else if (PyList_Check(object)) {
             writer->StartArray();

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -7,13 +7,19 @@ import random
 @pytest.mark.unit
 @pytest.mark.parametrize(
     'value', [
-        'A', 1, -1, 2.3, {'foo': 'bar'}, [1, 2, 'a', 1.2, {'foo': 'bar'},],
+        'A', 'cruel\x00world', 1, -1, 2.3, {'foo': 'bar'}, [1, 2, 'a', 1.2, {'foo': 'bar'},],
         sys.maxsize
 ])
 def test_base_values(value):
     dumped = rapidjson.dumps(value)
     loaded = rapidjson.loads(dumped)
     assert loaded == value
+
+
+@pytest.mark.unit
+def test_bytes_value():
+    dumped = rapidjson.dumps(b'cruel\x00world')
+    assert dumped == r'"cruel\u0000world"'
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Explicitly pass the string length to writer->String() when dumping str
and bytes values.