### PR TITLE
Explicit check for Python 3, to fail very early if using version 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,15 @@
 import os.path
 import re
+import sys
 
 try:
     from setuptools import setup, Extension
 except ImportError:
     from distutils.core import setup, Extension
+
+
+if sys.version_info < (3,):
+    raise NotImplementedError("Only Python 3+ is supported.")
 
 ROOT_PATH = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
This fixes issue #37 by emitting a `NotImplementedError` very early when trying to execute the setup.py with Python 2.

Maybe the error could suggest looking at [pyrapidjson](https://pypi.python.org/pypi/pyrapidjson), for extra courtesy...